### PR TITLE
Fix: Video Aspect Ratio and View Count Display

### DIFF
--- a/VistaVid/Models/InteractionCounts.swift
+++ b/VistaVid/Models/InteractionCounts.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+struct InteractionCounts: Codable, Equatable {
+    var likes: Int
+    var shares: Int
+    var comments: Int
+    var saves: Int
+    var views: Int
+    
+    init(likes: Int = 0, shares: Int = 0, comments: Int = 0, saves: Int = 0, views: Int = 0) {
+        self.likes = likes
+        self.shares = shares
+        self.comments = comments
+        self.saves = saves
+        self.views = views
+    }
+    
+    // MARK: - Codable
+    enum CodingKeys: String, CodingKey {
+        case likes, shares, comments, saves, views
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        likes = try container.decode(Int.self, forKey: .likes)
+        shares = try container.decode(Int.self, forKey: .shares)
+        comments = try container.decode(Int.self, forKey: .comments)
+        saves = try container.decode(Int.self, forKey: .saves)
+        views = try container.decodeIfPresent(Int.self, forKey: .views) ?? 0
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(likes, forKey: .likes)
+        try container.encode(shares, forKey: .shares)
+        try container.encode(comments, forKey: .comments)
+        try container.encode(saves, forKey: .saves)
+        try container.encode(views, forKey: .views)
+    }
+} 

--- a/VistaVid/Models/Video.swift
+++ b/VistaVid/Models/Video.swift
@@ -194,11 +194,12 @@ extension Video {
                 likes: countsDict["likes"] ?? 0,
                 shares: countsDict["shares"] ?? 0,
                 comments: countsDict["comments"] ?? 0,
-                saves: countsDict["saves"] ?? 0
+                saves: countsDict["saves"] ?? 0,
+                views: countsDict["views"] ?? 0
             )
         } else {
             print("⚠️ [Video Parser] No interactionCounts found, using defaults")
-            interactionCounts = InteractionCounts(likes: 0, shares: 0, comments: 0, saves: 0)
+            interactionCounts = InteractionCounts(likes: 0, shares: 0, comments: 0, saves: 0, views: 0)
         }
         
         // Parse business data with logging
@@ -266,7 +267,8 @@ extension Video {
                 "likes": interactionCounts.likes,
                 "shares": interactionCounts.shares,
                 "comments": interactionCounts.comments,
-                "saves": interactionCounts.saves
+                "saves": interactionCounts.saves,
+                "views": interactionCounts.views
             ],
             "createdAt": Timestamp(date: createdAt),
             "algorithmTags": algorithmTags,
@@ -307,6 +309,15 @@ extension Video {
         var shares: Int
         var comments: Int
         var saves: Int
+        var views: Int
+        
+        init(likes: Int = 0, shares: Int = 0, comments: Int = 0, saves: Int = 0, views: Int = 0) {
+            self.likes = likes
+            self.shares = shares
+            self.comments = comments
+            self.saves = saves
+            self.views = views
+        }
     }
 }
 
@@ -322,7 +333,13 @@ extension Video {
             genre: "Pop",
             uploadTimestamp: ISO8601DateFormatter().string(from: Date()),
             preprocessedTutorial: false,
-            interactionCounts: InteractionCounts(likes: 0, shares: 0, comments: 0, saves: 0)
+            interactionCounts: InteractionCounts(
+                likes: 0,
+                shares: 0,
+                comments: 0,
+                saves: 0,
+                views: 0
+            )
         )
     }
 } 

--- a/VistaVid/ViewModels/VideoViewModel.swift
+++ b/VistaVid/ViewModels/VideoViewModel.swift
@@ -212,7 +212,13 @@ final class VideoViewModel: ObservableObject {
                 genre: "Other",
                 uploadTimestamp: ISO8601DateFormatter().string(from: Date()),
                 preprocessedTutorial: false,
-                interactionCounts: Video.InteractionCounts(likes: 0, shares: 0, comments: 0, saves: 0),
+                interactionCounts: Video.InteractionCounts(
+                    likes: 0,
+                    shares: 0,
+                    comments: 0,
+                    saves: 0,
+                    views: 0
+                ),
                 user: nil,
                 thumbnailUrl: nil,
                 createdAt: Date(),

--- a/VistaVid/ViewModels/VideoViewModel.swift
+++ b/VistaVid/ViewModels/VideoViewModel.swift
@@ -797,6 +797,32 @@ final class VideoViewModel: ObservableObject {
             throw error
         }
     }
+    
+    // MARK: - View Count Methods
+    func incrementViewCount(for video: Video) async throws {
+        debugLog("👁️ Incrementing view count for video: \(video.id)")
+        
+        let videoRef = db.collection("videos").document(video.id)
+        
+        do {
+            // Increment view count in Firestore
+            try await updateVideoData([
+                "interactionCounts.views": FieldValue.increment(Int64(1))
+            ], for: videoRef)
+            
+            // Update local video object
+            if let index = videos.firstIndex(where: { $0.id == video.id }) {
+                var updatedVideo = videos[index]
+                updatedVideo.interactionCounts.views += 1
+                videos[index] = updatedVideo
+            }
+            
+            debugLog("✅ Successfully incremented view count")
+        } catch {
+            debugLog("❌ Error incrementing view count: \(error)")
+            throw error
+        }
+    }
 }
 
 // MARK: - Array Extension

--- a/VistaVid/Views/Components/VideoCardView.swift
+++ b/VistaVid/Views/Components/VideoCardView.swift
@@ -10,21 +10,13 @@ struct VideoCardView: View {
     var body: some View {
         GeometryReader { geometry in
             ZStack {
-                // Video Background - blurred for edges
-                if let url = URL(string: video.videoUrl) {
-                    VideoPlayerView(url: url, shouldPlay: isCurrentlyPlaying)
-                        .blur(radius: 30)
-                        .frame(width: geometry.size.width, height: geometry.size.height)
-                        .ignoresSafeArea()
-                }
-                
-                // Main Video Player
+                // Single Video Player with optimized layout
                 if let url = URL(string: video.videoUrl) {
                     VideoPlayerView(url: url, shouldPlay: isCurrentlyPlaying)
                         .aspectRatio(contentMode: .fill)
                         .frame(width: geometry.size.width, height: geometry.size.height)
                         .clipped()
-                        .ignoresSafeArea()
+                        .background(Color.black)
                 }
                 
                 // Gradient overlay for better text visibility
@@ -37,7 +29,6 @@ struct VideoCardView: View {
                     startPoint: .top,
                     endPoint: .bottom
                 )
-                .ignoresSafeArea()
                 
                 // Double tap gesture for like
                 Color.clear
@@ -50,9 +41,7 @@ struct VideoCardView: View {
                     Spacer()
                     HStack(alignment: .bottom, spacing: 16) {
                         // Video info
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text(video.title)
-                                .font(.headline)
+                        VStack(alignment: .leading, spacing: 6) {
                             Text(video.description)
                                 .font(.subheadline)
                                 .lineLimit(2)
@@ -76,13 +65,13 @@ struct VideoCardView: View {
                         Spacer()
                         
                         // Interaction buttons
-                        VStack(spacing: 24) {
+                        VStack(spacing: 20) {
                             VStack(spacing: 4) {
-                                Image(systemName: "heart.fill")
-                                    .font(.system(size: 30))
+                                Image(systemName: "play.circle.fill")
+                                    .font(.system(size: 24))
                                     .foregroundStyle(.white)
                                     .shadow(color: .black.opacity(0.3), radius: 8, x: 0, y: 4)
-                                Text("\(video.likesCount)")
+                                Text("\(video.interactionCounts.views)")
                                     .font(.caption)
                                     .bold()
                             }
@@ -108,7 +97,7 @@ struct VideoCardView: View {
                         .foregroundStyle(.white)
                     }
                     .padding(.horizontal, 16)
-                    .padding(.bottom, 90) // Add extra padding to clear the tab bar
+                    .padding(.bottom, 110) // Increased bottom padding to raise content higher
                 }
             }
         }

--- a/VistaVid/Views/Components/VideoCardView.swift
+++ b/VistaVid/Views/Components/VideoCardView.swift
@@ -12,7 +12,7 @@ struct VideoCardView: View {
             ZStack {
                 // Single Video Player with optimized layout
                 if let url = URL(string: video.videoUrl) {
-                    VideoPlayerView(url: url, shouldPlay: isCurrentlyPlaying)
+                    VideoPlayerView(url: url, shouldPlay: isCurrentlyPlaying, video: video)
                         .aspectRatio(contentMode: .fill)
                         .frame(width: geometry.size.width, height: geometry.size.height)
                         .clipped()
@@ -67,11 +67,11 @@ struct VideoCardView: View {
                         // Interaction buttons
                         VStack(spacing: 20) {
                             VStack(spacing: 4) {
-                                Image(systemName: "play.circle.fill")
+                                Image(systemName: "heart.fill")
                                     .font(.system(size: 24))
                                     .foregroundStyle(.white)
                                     .shadow(color: .black.opacity(0.3), radius: 8, x: 0, y: 4)
-                                Text("\(video.interactionCounts.views)")
+                                Text("\(video.interactionCounts.likes)")
                                     .font(.caption)
                                     .bold()
                             }

--- a/VistaVid/Views/Components/VideoFeedView.swift
+++ b/VistaVid/Views/Components/VideoFeedView.swift
@@ -73,8 +73,8 @@ private struct VideoCardContainer: View {
             onProfileTap: onProfileTap
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .offset(y: CGFloat(index - currentIndex) * UIScreen.main.bounds.height + dragOffset)
-        .frame(maxHeight: .infinity, alignment: .center)
+        .animation(.easeInOut(duration: 0.25), value: currentIndex)
+        .offset(y: (CGFloat(index - currentIndex) * UIScreen.main.bounds.height) + dragOffset)
     }
 }
 
@@ -200,7 +200,8 @@ struct VideoFeedView: View {
     }
     
     private func shouldRenderVideo(at index: Int) -> Bool {
-        abs(index - viewModel.currentIndex) <= 1
+        // Keep 2 videos loaded in each direction for smoother transitions
+        abs(index - viewModel.currentIndex) <= 2
     }
     
     private func createDragGesture(geometry: GeometryProxy) -> some Gesture {
@@ -233,12 +234,22 @@ struct VideoFeedView: View {
             )
             
             if newIndex != viewModel.currentIndex {
-                viewModel.currentIndex = newIndex
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    viewModel.currentIndex = newIndex
+                    dragOffset = 0
+                }
+            } else {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    dragOffset = 0
+                }
+            }
+        } else {
+            withAnimation(.easeInOut(duration: 0.25)) {
+                dragOffset = 0
             }
         }
         
-        dragOffset = 0
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
             isAnimating = false
         }
     }

--- a/VistaVid/Views/Components/VideoGridComponents.swift
+++ b/VistaVid/Views/Components/VideoGridComponents.swift
@@ -3,31 +3,22 @@ import AVKit
 
 // MARK: - Videos Grid Section
 struct VideosGridSection: View {
-    let title: String
     let videos: [Video]
     let onVideoTap: (Video) -> Void
     let onDelete: ((Video) -> Void)?
     
     var body: some View {
-        VStack(alignment: .leading) {
-            if !title.isEmpty {
-                Text(title)
-                    .font(.headline)
-                    .padding(.horizontal)
-            }
-            
-            LazyVGrid(columns: [
-                GridItem(.flexible(), spacing: 1),
-                GridItem(.flexible(), spacing: 1),
-                GridItem(.flexible(), spacing: 1)
-            ], spacing: 1) {
-                ForEach(videos) { video in
-                    VideoThumbnail(
-                        video: video,
-                        onTap: { onVideoTap(video) },
-                        onDelete: onDelete != nil ? { onDelete?(video) } : nil
-                    )
-                }
+        LazyVGrid(columns: [
+            GridItem(.flexible(), spacing: 1),
+            GridItem(.flexible(), spacing: 1),
+            GridItem(.flexible(), spacing: 1)
+        ], spacing: 1) {
+            ForEach(videos) { video in
+                VideoThumbnail(
+                    video: video,
+                    onTap: { onVideoTap(video) },
+                    onDelete: onDelete != nil ? { onDelete?(video) } : nil
+                )
             }
         }
     }

--- a/VistaVid/Views/Components/VideoThumbnail.swift
+++ b/VistaVid/Views/Components/VideoThumbnail.swift
@@ -32,10 +32,11 @@ struct VideoThumbnail: View {
                 VStack {
                     Spacer()
                     HStack {
-                        Image(systemName: "play.fill")
+                        Image(systemName: "play.circle.fill")
+                            .font(.system(size: 16))
                             .foregroundStyle(.white.opacity(0.6))
                         if let video = video {
-                            Text("❤️ \(video.interactionCounts.likes)")
+                            Text("\(video.interactionCounts.views)")
                                 .font(.caption)
                                 .foregroundStyle(.white.opacity(0.6))
                         }

--- a/VistaVid/Views/Components/VideoThumbnail.swift
+++ b/VistaVid/Views/Components/VideoThumbnail.swift
@@ -32,7 +32,7 @@ struct VideoThumbnail: View {
                 VStack {
                     Spacer()
                     HStack {
-                        Image(systemName: "play.circle.fill")
+                        Image(systemName: "play.fill")
                             .font(.system(size: 16))
                             .foregroundStyle(.white.opacity(0.6))
                         if let video = video {

--- a/VistaVid/Views/FYPView.swift
+++ b/VistaVid/Views/FYPView.swift
@@ -182,7 +182,8 @@ struct FYPView: View {
                             onProfileTap: { _ in }
                         )
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .offset(y: CGFloat(index - viewModel.currentIndex) * geometry.size.height + dragOffset)
+                        .animation(.easeInOut(duration: 0.25), value: viewModel.currentIndex)
+                        .offset(y: (CGFloat(index - viewModel.currentIndex) * geometry.size.height) + dragOffset)
                     }
                 }
                 
@@ -235,7 +236,7 @@ struct FYPView: View {
             .clipped()
             .transaction { transaction in
                 transaction.animation = isAnimating ? 
-                    .interpolatingSpring(stiffness: 200, damping: 25) : nil
+                    .easeInOut(duration: 0.25) : nil
             }
             .gesture(createDragGesture(geometry: geometry))
             .offset(y: -30)
@@ -255,7 +256,8 @@ struct FYPView: View {
     }
     
     private func shouldRenderVideo(at index: Int) -> Bool {
-        let shouldRender = abs(index - viewModel.currentIndex) <= 1
+        // Keep 2 videos loaded in each direction for smoother transitions
+        let shouldRender = abs(index - viewModel.currentIndex) <= 2
         print("🎥 [FYP] Checking if should render video at index \(index): \(shouldRender)")
         return shouldRender
     }
@@ -291,7 +293,10 @@ struct FYPView: View {
             
             if newIndex != viewModel.currentIndex {
                 print("🔄 [FYP] Changing current index from \(viewModel.currentIndex) to \(newIndex)")
-                viewModel.currentIndex = newIndex
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    viewModel.currentIndex = newIndex
+                    dragOffset = 0
+                }
                 
                 // Only try to load more if we're not at the end
                 if !viewModel.hasReachedEnd && newIndex >= viewModel.videos.count - 2 {
@@ -300,11 +305,18 @@ struct FYPView: View {
                         await viewModel.loadMoreVideosIfNeeded()
                     }
                 }
+            } else {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    dragOffset = 0
+                }
+            }
+        } else {
+            withAnimation(.easeInOut(duration: 0.25)) {
+                dragOffset = 0
             }
         }
         
-        dragOffset = 0
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
             isAnimating = false
         }
     }

--- a/VistaVid/Views/ProfileView.swift
+++ b/VistaVid/Views/ProfileView.swift
@@ -66,7 +66,7 @@ struct ProfileView: View {
                     if selectedTab == 0 {
                         if userVideos.isEmpty {
                             VStack(spacing: 12) {
-                                Image(systemName: "video.fill")
+                                Image(systemName: "play.fill")
                                     .font(.system(size: 40))
                                     .foregroundColor(.secondary)
                                     .padding(.top, 40)
@@ -80,7 +80,6 @@ struct ProfileView: View {
                             .padding(.horizontal)
                         } else {
                             VideosGridSection(
-                                title: "Posts",
                                 videos: userVideos,
                                 onVideoTap: { video in
                                     // Handle video tap
@@ -108,7 +107,6 @@ struct ProfileView: View {
                             .padding(.horizontal)
                         } else {
                             VideosGridSection(
-                                title: "Likes",
                                 videos: likedVideos,
                                 onVideoTap: { video in
                                     // Handle video tap

--- a/VistaVid/Views/UserProfileView.swift
+++ b/VistaVid/Views/UserProfileView.swift
@@ -161,7 +161,6 @@ struct UserProfileView: View {
                         .padding(.horizontal)
                     } else {
                         VideosGridSection(
-                            title: "",
                             videos: userVideos,
                             onVideoTap: { video in
                                 selectedVideo = video
@@ -188,7 +187,6 @@ struct UserProfileView: View {
                         .padding(.horizontal)
                     } else {
                         VideosGridSection(
-                            title: "",
                             videos: likedVideos,
                             onVideoTap: { video in
                                 selectedVideo = video

--- a/todo/todo.md
+++ b/todo/todo.md
@@ -1,13 +1,24 @@
 ### TODO
 
 #Week 6
+[ ] Profile page emoji + text clean up
+[ ] Redo likes
+[ ] Redo comments
+[ ] Redo shares
+[ ] Redo like animation
+[ ] Redo hands free mode
+[ ] Redo play/pause button
+[ ] Redo community feed
+[ ] DM message persistence
+[ ] Bio
+[ ] Algoriothm utility function
 [ ] settings clean up - UI is a little weird and there's a lot of bricked links on there like the privacy policy.
-[ ] Feed navigation is buggy - fast scrolling causesaudio to track the wrong video and video to play when another tab is pressed.
-[ ] Community page shows blank on long press
-[ ] Record and display Views
+[ ] Display Views
 [ ] Algorithm Accountability - currently just UI on settings. Improve UI/UX and implement funcitonality.
 [ ] Content Moderation
-[ ] Content loading - feed takes 2s to laod every video
 [ ] segmentation fault race condition - happens sproadically on app initializations
+[-] Community page shows blank on long press
+[X] Feed navigation is buggy - fast scrolling causesaudio to track the wrong video and video to play when another tab is pressed.
+[X] Content loading - feed takes 2s to laod every video
 [X] Hands Free Mode
 [X] play/pause button

--- a/todo/todo.md
+++ b/todo/todo.md
@@ -1,7 +1,6 @@
 ### TODO
 
 #Week 6
-[ ] Profile page emoji + text clean up
 [ ] Redo likes
 [ ] Redo comments
 [ ] Redo shares
@@ -18,6 +17,7 @@
 [ ] Content Moderation
 [ ] segmentation fault race condition - happens sproadically on app initializations
 [-] Community page shows blank on long press
+[X] Profile page emoji + text clean up
 [X] Feed navigation is buggy - fast scrolling causesaudio to track the wrong video and video to play when another tab is pressed.
 [X] Content loading - feed takes 2s to laod every video
 [X] Hands Free Mode


### PR DESCRIPTION
This PR fixes two main issues:

1. Video Aspect Ratio
- Reverts to the working aspect ratio implementation
- Uses consistent .resizeAspect for all videos
- Prevents unwanted zooming/cropping

2. View Count Display
- Maintains the view count functionality
- Preserves profile page revisions
- Ensures proper display of view counts in UI

Changes included:
- Fixed video player aspect ratio
- Maintained view count tracking
- Preserved profile page improvements